### PR TITLE
Replace Omniuser name column with first_name and last_name

### DIFF
--- a/app/models/omniuser.rb
+++ b/app/models/omniuser.rb
@@ -17,7 +17,8 @@ class Omniuser < ApplicationRecord
 
     unless omniuser
         omniuser = Omniuser.create(
-          name: data['name'],
+          first_name: data['first_name'],
+          last_name: data['last_name'],
           email: data['email'],
           password: Devise.friendly_token[0,20]
         )

--- a/db/migrate/20191028015857_add_first_and_last_name_omniuser.rb
+++ b/db/migrate/20191028015857_add_first_and_last_name_omniuser.rb
@@ -1,0 +1,8 @@
+class AddFirstAndLastNameOmniuser < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :omniusers, :name
+    add_column :omniusers, :first_name, :string
+    add_column :omniusers, :last_name, :string
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_12_044313) do
+ActiveRecord::Schema.define(version: 2019_10_28_015857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,8 +35,9 @@ ActiveRecord::Schema.define(version: 2019_10_12_044313) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "name"
     t.string "user_type"
+    t.string "first_name"
+    t.string "last_name"
     t.index ["email"], name: "index_omniusers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_omniusers_on_reset_password_token", unique: true
   end
@@ -44,7 +45,7 @@ ActiveRecord::Schema.define(version: 2019_10_12_044313) do
   create_table "paperworks", force: :cascade do |t|
     t.string "link"
     t.string "title"
-    t.boolean "agree"
+    t.boolean "agree", default: false
     t.bigint "staff_id", null: false
     t.bigint "participant_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,9 +5,15 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-    staff_member = Omniuser.create!(name: "UnloopStaff", email: "unloopauth@gmail.com",
-                                    user_type: "Staff", password: "staffs")
+    staff_member = Omniuser.create!(first_name: "Unloop",
+                                    last_name: "Staff",
+                                    email: "unloopauth@gmail.com",
+                                    user_type: "Staff",
+                                    password: "staffs")
     staff_member.create_staff!()
-    participant_member = Omniuser.create!(name: "TestParticipant", email: "unlooptestparticipant@gmail.com",
-                                          user_type: "Participant", password: "participant")
+    participant_member = Omniuser.create!(first_name: "Unloop",
+                                          last_name: "Participant",
+                                          email: "unlooptestparticipant@gmail.com",
+                                          user_type: "Participant",
+                                          password: "participant")
     participant_member.create_participant!()


### PR DESCRIPTION

## Replaced Omniuser's `name` column with `first_name` and `last_name`

Changed seeds to correctly match first and last name and changed the omniuser creating method to populate first and last name

### Created new migration to remove `name` column and add `first_name` and `last_name`

CC: @adowski