### PR TITLE
Paperwork/CaseNote does not refresh page on creation/edit. Made CaseNoteCard and ParticipantCard Functional.

### DIFF
--- a/app/javascript/components/CaseNoteCard/index.js
+++ b/app/javascript/components/CaseNoteCard/index.js
@@ -4,7 +4,7 @@
  *
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
@@ -15,119 +15,94 @@ import DeleteModal from 'components/DeleteModal';
 import CaseNoteCardModal from 'components/CaseNoteCardModal';
 import styles from './styles';
 
-class CaseNoteCard extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      description: this.props.description,
-      title: this.props.title,
-      internal: this.props.internal,
-      id: this.props.id,
-      anchorEl: null,
-      participantId: this.props.participantId,
-    };
-    this.handleClick = this.handleClick.bind(this);
-    this.handleMenuClose = this.handleMenuClose.bind(this);
-  }
+function CaseNoteCard({
+  classes,
+  description,
+  title,
+  internal,
+  caseNoteId,
+  participantId,
+  showMenu,
+  updateCaseNote,
+}) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const handleMenuClick = event => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
+  const renderMenuItems = () => (
+    <div>
+      <IconButton
+        aria-label="more"
+        aria-controls="long-menu"
+        aria-haspopup="true"
+        onClick={handleMenuClick}
+      >
+        <MoreHorizIcon />
+      </IconButton>
+      <Menu
+        id="long-menu"
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleMenuClose}
+        PaperProps={{
+          style: {
+            maxHeight: 180,
+            width: 200,
+          },
+        }}
+      >
+        <CaseNoteForm
+          type="edit"
+          title={title}
+          description={description}
+          internal={internal}
+          participantId={participantId}
+          caseNoteId={caseNoteId}
+          updateCaseNote={updateCaseNote}
+        />
+        <DeleteModal
+          message="Are you sure you want to delete this casenote?"
+          body={{
+            title,
+            description,
+            internal,
+            participant_id: participantId,
+          }}
+          req={`/api/case_notes/${caseNoteId}`}
+        />
+      </Menu>
+    </div>
+  );
 
-  handleClick(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleMenuClose() {
-    this.setState({ anchorEl: null });
-  }
-
-  // eslint-disable-next-line consistent-return
-  renderMenuItems() {
-    if (this.props.showMenu) {
-      return (
-        <div>
-          <IconButton
-            aria-label="more"
-            aria-controls="long-menu"
-            aria-haspopup="true"
-            onClick={this.handleClick}
-          >
-            <MoreHorizIcon />
-          </IconButton>
-          <Menu
-            id="long-menu"
-            anchorEl={this.state.anchorEl}
-            open={Boolean(this.state.anchorEl)}
-            onClose={this.handleMenuClose}
-            PaperProps={{
-              style: {
-                maxHeight: 180,
-                width: 200,
-              },
-            }}
-          >
-            <CaseNoteForm
-              type="edit"
-              title={this.state.title}
-              description={this.state.description}
-              internal={this.state.internal}
-              participantId={this.state.participantId}
-              id={this.state.id}
-            />
-            <DeleteModal
-              message="Are you sure you want to delete this casenote?"
-              body={{
-                title: this.state.title,
-                description: this.state.description,
-                internal: this.state.internal,
-                participant_id: this.props.participantId,
-              }}
-              req={`/api/case_notes/${this.state.id}`}
-            />
-          </Menu>
-        </div>
-      );
-    }
-  }
-
-  render() {
-    // eslint-disable-next-line no-unused-vars
-    const { classes } = this.props;
-    return (
-      <>
-        <Grid container spacing={3}>
-          <Grid item xs={11}>
-            <Paper className={classes.caseNoteCardStyle}>
-              <Grid container spacing={2}>
-                <Grid item xs={10}>
-                  <h3 className={classes.casenoteCardTitleStyle}>
-                    {this.state.title}
-                  </h3>
-                </Grid>
-                <Grid item xs={2}>
-                  {this.renderMenuItems()}
-                </Grid>
-              </Grid>
-              <div className={classes.caseNoteDescStyle}>
-                <MUIRichTextEditor
-                  value={this.state.description}
-                  readOnly
-                  toolbar={false}
-                />
-              </div>
-
-              <Grid container spacing={2} className={classes.buttonStyle}>
-                <Grid item xs={8}></Grid>
-                <Grid item xs={4}>
-                  <CaseNoteCardModal
-                    description={this.state.description}
-                    title={this.state.title}
-                  />
-                </Grid>
-              </Grid>
-            </Paper>
+  return (
+    <Grid container spacing={3}>
+      <Grid item xs={11}>
+        <Paper className={classes.caseNoteCardStyle}>
+          <Grid container spacing={2}>
+            <Grid item xs={10}>
+              <h3 className={classes.casenoteCardTitleStyle}>{title}</h3>
+            </Grid>
+            <Grid item xs={2}>
+              {showMenu ? renderMenuItems() : null}
+            </Grid>
           </Grid>
-        </Grid>
-      </>
-    );
-  }
+          <div className={classes.caseNoteDescStyle}>
+            <MUIRichTextEditor value={description} readOnly toolbar={false} />
+          </div>
+
+          <Grid container spacing={2} className={classes.buttonStyle}>
+            <Grid item xs={8}></Grid>
+            <Grid item xs={4}>
+              <CaseNoteCardModal description={description} title={title} />
+            </Grid>
+          </Grid>
+        </Paper>
+      </Grid>
+    </Grid>
+  );
 }
 
 CaseNoteCard.propTypes = {
@@ -135,9 +110,10 @@ CaseNoteCard.propTypes = {
   description: PropTypes.string,
   title: PropTypes.string,
   internal: PropTypes.bool,
-  id: PropTypes.number,
+  caseNoteId: PropTypes.number.isRequired,
   participantId: PropTypes.number,
   showMenu: PropTypes.bool,
+  updateCaseNote: PropTypes.func,
 };
 
 export default withStyles(styles)(CaseNoteCard);

--- a/app/javascript/components/CaseNoteCardModal/index.js
+++ b/app/javascript/components/CaseNoteCardModal/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import MUIRichTextEditor from 'mui-rte';
 import 'draft-js/dist/Draft.css';
@@ -31,73 +31,51 @@ Object.assign(defaultTheme, {
   },
 });
 
-class CaseNoteCardModal extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      description: this.props.description,
-      title: this.props.title,
-      open: false,
-    };
-    this.handleClose = this.handleClose.bind(this);
-    this.handleOpen = this.handleOpen.bind(this);
-  }
+function CaseNoteCardModal({ classes, description, title }) {
+  const [open, setOpen] = useState(false);
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
-
-  handleClose() {
-    this.setState({ open: false });
-  }
-
-  render() {
-    const { classes } = this.props;
-
-    return (
-      <>
-        <div className={classes.buttonStyle}>
-          <Button
-            className="contained"
-            color="primary"
-            onClick={this.handleOpen}
-          >
-            VIEW MORE
-          </Button>
-        </div>
-
-        <Dialog
-          className={classes.dialogStyle}
-          open={this.state.open}
-          onClose={this.handleClose}
-          aria-labelledby="form-dialog-title"
-          maxWidth="md"
+  return (
+    <>
+      <div className={classes.buttonStyle}>
+        <Button
+          className="contained"
+          color="primary"
+          onClick={() => setOpen(true)}
         >
-          <div className={classes.backgroundColor}>
-            <div className={classes.modalItems}>
-              <Grid container spacing={2}>
-                <Grid item xs={12}>
-                  <h3 className={classes.titleStyle}>{this.state.title}</h3>
-                </Grid>
+          VIEW MORE
+        </Button>
+      </div>
 
-                <Grid item xs={12}>
-                  <Paper className={classes.caseNoteCardModalDescriptionStyle}>
-                    <div className={classes.caseNoteDescStyle}>
-                      <MUIRichTextEditor
-                        value={this.state.description}
-                        readOnly
-                        toolbar={false}
-                      />
-                    </div>
-                  </Paper>
-                </Grid>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        aria-labelledby="form-dialog-title"
+        maxWidth="md"
+      >
+        <div className={classes.backgroundColor}>
+          <div className={classes.modalItems}>
+            <Grid container spacing={2}>
+              <Grid item xs={12}>
+                <h3 className={classes.titleStyle}>{title}</h3>
               </Grid>
-            </div>
+
+              <Grid item xs={12}>
+                <Paper className={classes.caseNoteCardModalDescriptionStyle}>
+                  <div className={classes.caseNoteDescStyle}>
+                    <MUIRichTextEditor
+                      value={description}
+                      readOnly
+                      toolbar={false}
+                    />
+                  </div>
+                </Paper>
+              </Grid>
+            </Grid>
           </div>
-        </Dialog>
-      </>
-    );
-  }
+        </div>
+      </Dialog>
+    </>
+  );
 }
 
 CaseNoteCardModal.propTypes = {

--- a/app/javascript/components/CaseNoteContainer/index.js
+++ b/app/javascript/components/CaseNoteContainer/index.js
@@ -17,6 +17,8 @@ class CaseNoteContainer extends React.Component {
       participant: this.props.participant,
       userType: this.props.userType,
     };
+    this.appendCaseNote = this.appendCaseNote.bind(this);
+    this.updateCaseNote = this.updateCaseNote.bind(this);
   }
 
   formatDate(dateString) {
@@ -34,6 +36,7 @@ class CaseNoteContainer extends React.Component {
           <CaseNoteForm
             type="create"
             participantId={this.state.participant.id}
+            appendCaseNote={this.appendCaseNote}
           />
         </Grid>
       );
@@ -41,22 +44,41 @@ class CaseNoteContainer extends React.Component {
     return null;
   }
 
+  appendCaseNote(caseNote) {
+    this.setState(prevState => ({
+      caseNotes: [caseNote, ...prevState.caseNotes],
+    }));
+  }
+
+  updateCaseNote(updatedCaseNote) {
+    this.setState(prevState => {
+      const updatedCaseNotes = [...prevState.caseNotes];
+      const caseNoteIndex = updatedCaseNotes.findIndex(
+        caseNote => caseNote.id === updatedCaseNote.id,
+      );
+      if (caseNoteIndex !== -1) {
+        updatedCaseNotes[caseNoteIndex] = updatedCaseNote;
+        return { caseNotes: updatedCaseNotes };
+      }
+      return {};
+    });
+  }
+
   renderCaseNoteCards() {
     const { classes } = this.props;
 
     if (this.state.caseNotes.length !== 0) {
       const caseNoteCards = this.state.caseNotes.map(caseNote => (
-        <div key={caseNote.id}>
-          <CaseNoteCard
-            title={caseNote.title}
-            description={caseNote.description}
-            internal={caseNote.internal}
-            id={caseNote.id}
-            participantId={this.state.participant.id}
-            showMenu={this.state.userType === 'staff'}
-            date={this.formatDate(caseNote.created_at)}
-          />
-        </div>
+        <CaseNoteCard
+          key={caseNote.id}
+          title={caseNote.title}
+          description={caseNote.description}
+          internal={caseNote.internal}
+          caseNoteId={caseNote.id}
+          participantId={this.state.participant.id}
+          showMenu={this.state.userType === 'staff'}
+          updateCaseNote={this.updateCaseNote}
+        />
       ));
       return caseNoteCards;
     }

--- a/app/javascript/components/CaseNoteForm/index.js
+++ b/app/javascript/components/CaseNoteForm/index.js
@@ -29,7 +29,7 @@ class CaseNoteForm extends React.Component {
       internal: this.props.internal,
       open: false,
       type: this.props.type,
-      id: this.props.id,
+      caseNoteId: this.props.caseNoteId,
       tempDescription: this.props.description,
       errors: {
         title: '',
@@ -111,7 +111,14 @@ class CaseNoteForm extends React.Component {
         };
 
         apiPost('/api/case_notes', { case_note: body })
-          .then(() => window.location.reload())
+          .then(response => {
+            if (this.props.appendCaseNote) {
+              this.props.appendCaseNote(response.data);
+            } else if (this.props.incrementNumCaseNotes) {
+              this.props.incrementNumCaseNotes();
+            }
+            this.handleClose();
+          })
           .catch(error => console.error(error));
       } else {
         this.setState(prevState => ({
@@ -124,9 +131,13 @@ class CaseNoteForm extends React.Component {
           internal: this.state.internal,
           participant_id: this.state.participant_id,
         };
-
-        apiPatch(`/api/case_notes/${this.state.id}`, { case_note: body })
-          .then(() => window.location.reload())
+        apiPatch(`/api/case_notes/${this.state.caseNoteId}`, {
+          case_note: body,
+        })
+          .then(response => {
+            this.props.updateCaseNote(response.data);
+            this.setState({ open: false });
+          })
           .catch(error => console.error(error));
       }
     }
@@ -284,8 +295,11 @@ CaseNoteForm.propTypes = {
   description: PropTypes.string,
   internal: PropTypes.bool,
   display: PropTypes.string,
-  id: PropTypes.number,
+  caseNoteId: PropTypes.number,
   participantId: PropTypes.number.isRequired,
+  incrementNumCaseNotes: PropTypes.func,
+  appendCaseNote: PropTypes.func,
+  updateCaseNote: PropTypes.func,
 };
 
 CaseNoteForm.defaultProps = {

--- a/app/javascript/components/PaperworkEntry/index.js
+++ b/app/javascript/components/PaperworkEntry/index.js
@@ -29,6 +29,7 @@ function PaperworkEntry({
   paperwork,
   userType,
   participantId,
+  updatePaperwork,
   // Used by style file
   // eslint-disable-next-line no-unused-vars
   lastEntry = false,
@@ -72,6 +73,7 @@ function PaperworkEntry({
             paperworkTitle={title}
             paperworkLink={link}
             paperworkId={id}
+            updatePaperwork={updatePaperwork}
           />
           <Button color="primary" href={link} target="_blank">
             View
@@ -166,6 +168,7 @@ PaperworkEntry.propTypes = {
   paperwork: PropTypes.object.isRequired,
   userType: PropTypes.oneOf(['staff', 'participant']),
   participantId: PropTypes.number.isRequired,
+  updatePaperwork: PropTypes.func,
   lastEntry: PropTypes.bool,
   id: PropTypes.number,
 };

--- a/app/javascript/components/PaperworkForm/index.js
+++ b/app/javascript/components/PaperworkForm/index.js
@@ -29,6 +29,9 @@ function PaperworkForm({
   paperworkTitle,
   paperworkLink,
   paperworkId,
+  appendPaperwork,
+  updatePaperwork,
+  incrementNumPaperworks,
   participantId,
   display,
 }) {
@@ -87,12 +90,22 @@ function PaperworkForm({
     if (!hasErrors) {
       if (type === 'create') {
         apiPost('/api/paperworks', { paperwork: body })
-          .then(() => window.location.reload())
+          .then(response => {
+            if (appendPaperwork) {
+              appendPaperwork(response.data);
+            } else if (incrementNumPaperworks) {
+              incrementNumPaperworks();
+            }
+            setOpen(false);
+          })
           .catch(error => console.error(error));
         // TODO: Change this to flash an error message
       } else if (type === 'edit') {
         apiPatch(`/api/paperworks/${paperworkId}`, { paperwork: body })
-          .then(() => window.location.reload())
+          .then(response => {
+            updatePaperwork(response.data);
+            setOpen(false);
+          })
           .catch(error => console.error(error));
         // TODO: Change this to flash an error message
       }
@@ -292,6 +305,9 @@ PaperworkForm.propTypes = {
   paperworkTitle: PropTypes.string,
   paperworkLink: PropTypes.string,
   participantId: PropTypes.number.isRequired,
+  appendPaperwork: PropTypes.func,
+  incrementNumPaperworks: PropTypes.func,
+  updatePaperwork: PropTypes.func,
   paperworkId: PropTypes.number,
   display: PropTypes.string,
 };

--- a/app/javascript/components/PaperworkList/index.js
+++ b/app/javascript/components/PaperworkList/index.js
@@ -4,7 +4,7 @@
  *
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import { Grid, Paper, List } from '@material-ui/core';
@@ -15,11 +15,24 @@ import styles from './styles';
 
 function PaperworkList({
   classes,
-  paperworks,
+  initialPaperworks,
   participantId,
   userType,
   formatDate,
 }) {
+  const [paperworks, setPaperworks] = useState(initialPaperworks);
+
+  const updatePaperwork = updatedPaperwork => {
+    const allPaperworks = [...paperworks];
+    const paperworkIndex = allPaperworks.findIndex(
+      paperwork => paperwork.id === updatedPaperwork.id,
+    );
+    if (paperworkIndex !== -1) {
+      allPaperworks[paperworkIndex] = updatedPaperwork;
+      setPaperworks(allPaperworks);
+    }
+  };
+
   const paperworkEntries = paperworks.map((paperwork, i) => (
     <PaperworkEntry
       key={paperwork.id}
@@ -27,6 +40,7 @@ function PaperworkList({
       participantId={participantId}
       userType={userType}
       date={formatDate(paperwork.created_at)}
+      updatePaperwork={updatePaperwork}
       lastEntry={paperworks.length - 1 === i}
     />
   ));
@@ -48,6 +62,9 @@ function PaperworkList({
             type="create"
             hide={userType !== 'staff'}
             participantId={participantId}
+            appendPaperwork={paperwork =>
+              setPaperworks([paperwork, ...paperworks])
+            }
           />
         </Grid>
       </Grid>
@@ -79,7 +96,7 @@ function PaperworkList({
 PaperworkList.propTypes = {
   userType: PropTypes.string.isRequired,
   classes: PropTypes.object.isRequired,
-  paperworks: PropTypes.array.isRequired,
+  initialPaperworks: PropTypes.array.isRequired,
   participantId: PropTypes.number.isRequired,
   formatDate: PropTypes.func.isRequired,
 };

--- a/app/javascript/components/ParticipantCard/index.js
+++ b/app/javascript/components/ParticipantCard/index.js
@@ -19,7 +19,11 @@ function ParticipantCard({ classes, participant }) {
     window.location.assign(`participants/${String(pId)}`);
   };
 
-  const [numCaseNotes, setNumCaseNotes] = useState(participant.caseNotesCount);
+  // disabled eslint to make styling consistent
+  // eslint-disable-next-line
+  const [numCaseNotes, setNumCaseNotes] = useState(
+    participant.caseNotesCount,
+  );
   const [numPaperworks, setNumPaperworks] = useState(
     participant.paperworksCount,
   );

--- a/app/javascript/components/ParticipantCard/index.js
+++ b/app/javascript/components/ParticipantCard/index.js
@@ -20,6 +20,9 @@ function ParticipantCard({ classes, participant }) {
   };
 
   const [numCaseNotes, setNumCaseNotes] = useState(participant.caseNotesCount);
+  const [numPaperworks, setNumPaperworks] = useState(
+    participant.paperworksCount,
+  );
 
   const questionnaireStatus = participant.questionnaireStatus ? (
     <FontAwesomeIcon
@@ -71,13 +74,13 @@ function ParticipantCard({ classes, participant }) {
       <td className={classes.newAssignment}>
         <div>
           <div className={classes.paperworkText}>
-            {participant.paperworksCompleted} / {participant.paperworksCount}{' '}
-            completed{' '}
+            {participant.paperworksCompleted} / {numPaperworks} completed{' '}
           </div>
           <PaperworkForm
             display="plus"
             type="create"
             participantId={participant.id}
+            incrementNumPaperworks={() => setNumPaperworks(numPaperworks + 1)}
           ></PaperworkForm>
         </div>
       </td>

--- a/app/javascript/components/ParticipantCard/index.js
+++ b/app/javascript/components/ParticipantCard/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import CaseNoteForm from 'components/CaseNoteForm';
 import PaperworkForm from 'components/PaperworkForm';
@@ -13,101 +13,99 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import theme from 'utils/theme';
 import styles from './styles';
 
-class ParticipantCard extends React.Component {
-  constructor(props) {
-    super(props);
-    this.showParticipant = this.showParticipant.bind(this);
-  }
-
-  showParticipant() {
-    const pId = this.props.participant.id;
+function ParticipantCard({ classes, participant }) {
+  const showParticipant = () => {
+    const pId = participant.id;
     window.location.assign(`participants/${String(pId)}`);
+  };
+
+  const [numCaseNotes, setNumCaseNotes] = useState(participant.caseNotesCount);
+
+  const questionnaireStatus = participant.questionnaireStatus ? (
+    <FontAwesomeIcon
+      className={classes.iconLarge}
+      icon={faCheck}
+      color="green"
+    ></FontAwesomeIcon>
+  ) : (
+    <FontAwesomeIcon
+      className={classes.iconLarge}
+      icon={faTimes}
+      color="red"
+    ></FontAwesomeIcon>
+  );
+
+  let statusColor;
+  const status = participant.status.toUpperCase();
+  if (status === 'R0') {
+    statusColor = theme.palette.primary.light;
+  } else if (status === 'R1') {
+    statusColor = '#5870EB';
+  } else {
+    statusColor = '#DF6C8E';
   }
 
-  render() {
-    const p = this.props.participant;
-    const { classes } = this.props;
-    const status = p.status.toUpperCase();
-    const { name } = p;
+  const caseNotes =
+    numCaseNotes === 1
+      ? `${numCaseNotes} case note`
+      : `${numCaseNotes} case notes`;
 
-    const questionnaireStatus = p.questionnaireStatus ? (
-      <FontAwesomeIcon
-        className={classes.iconLarge}
-        icon={faCheck}
-        color="green"
-      ></FontAwesomeIcon>
-    ) : (
-      <FontAwesomeIcon
-        className={classes.iconLarge}
-        icon={faTimes}
-        color="red"
-      ></FontAwesomeIcon>
-    );
-
-    let statusColor;
-    if (status === 'R0') {
-      statusColor = theme.palette.primary.light;
-    } else if (status === 'R1') {
-      statusColor = '#5870EB';
-    } else {
-      statusColor = '#DF6C8E';
-    }
-    const caseNotes =
-      p.caseNotesCount === 1
-        ? `${p.caseNotesCount} case note`
-        : `${p.caseNotesCount} case notes`;
-    return (
-      <tr>
-        <td
-          className={classes.name}
-          style={{ cursor: 'pointer' }}
-          onClick={this.showParticipant}
-          onKeyDown={this.showParticipant}
+  return (
+    <tr>
+      <td
+        className={classes.name}
+        style={{ cursor: 'pointer' }}
+        onClick={showParticipant}
+        onKeyDown={showParticipant}
+      >
+        {participant.name}
+      </td>
+      <td>
+        <div
+          className={classes.status}
+          style={{ backgroundColor: statusColor }}
         >
-          {name}
-        </td>
-        <td>
-          <div className={classes.status} style={{ backgroundColor: statusColor }}>
-            {status}
+          {status}
+        </div>
+      </td>
+      <td className={classes.newAssignment}>
+        <div>
+          <div className={classes.paperworkText}>
+            {participant.paperworksCompleted} / {participant.paperworksCount}{' '}
+            completed{' '}
           </div>
-        </td>
-        <td className={classes.newAssignment}>
-          <div>
-            <div className={classes.paperworkText}>{p.paperworksCompleted} / {p.paperworksCount} completed </div>
-            <PaperworkForm
-              display="plus"
-              type="create"
-              participantId={p.id}
-            ></PaperworkForm>
-          </div>
-        </td>
-        <td className={classes.newAssignment}>
-          <div>
-            <div className={classes.caseNoteText}>{caseNotes}</div>
-            <CaseNoteForm
-              display="plus"
-              type="create"
-              participantId={p.id}
-            ></CaseNoteForm>
-          </div>
-        </td>
-        <td>
-          <div className={classes.questionnaireStatus}>
-            {questionnaireStatus}
-          </div>
-        </td>
-        <td className={classes.arrow}>
-          <FontAwesomeIcon
-            onClick={this.showParticipant}
-            icon={faChevronRight}
-            color="grey"
-            style={{ cursor: 'pointer' }}
-            className={classes.iconLarge}
-          />
-        </td>
-      </tr>
-    );
-  }
+          <PaperworkForm
+            display="plus"
+            type="create"
+            participantId={participant.id}
+          ></PaperworkForm>
+        </div>
+      </td>
+      <td className={classes.newAssignment}>
+        <div>
+          <div className={classes.caseNoteText}>{caseNotes}</div>
+          <CaseNoteForm
+            display="plus"
+            type="create"
+            participantId={participant.id}
+            incrementNumCaseNotes={() => setNumCaseNotes(numCaseNotes + 1)}
+          ></CaseNoteForm>
+        </div>
+      </td>
+      <td>
+        <div className={classes.questionnaireStatus}>{questionnaireStatus}</div>
+      </td>
+      <td className={classes.arrow}>
+        <FontAwesomeIcon
+          onClick={showParticipant}
+          icon={faChevronRight}
+          color="grey"
+          style={{ cursor: 'pointer' }}
+          className={classes.iconLarge}
+        />
+      </td>
+    </tr>
+  );
 }
 
 ParticipantCard.propTypes = {

--- a/app/javascript/components/ParticipantShowPage/index.js
+++ b/app/javascript/components/ParticipantShowPage/index.js
@@ -99,7 +99,7 @@ class ParticipantShowPage extends React.Component {
               </Grid>
               <Grid item style={{ padding: '0px', marginTop: '20px' }}>
                 <PaperworkList
-                  paperworks={paperworks}
+                  initialPaperworks={paperworks}
                   participantId={participantId}
                   formatDate={this.formatDate}
                   userType={userType}

--- a/app/serializers/paperwork_serializer.rb
+++ b/app/serializers/paperwork_serializer.rb
@@ -1,5 +1,5 @@
 class PaperworkSerializer < ActiveModel::Serializer
-  attributes :id, :title, :link, :agree, :staff, :participant, :viewed
+  attributes :id, :title, :link, :agree, :staff, :participant, :viewed, :created_at, :updated_at
 
   belongs_to :staff, serializer: SimpleStaffSerializer
   belongs_to :participant, serializer: SimpleParticipantSerializer


### PR DESCRIPTION
This PR does two things.

This PR makes it so that creating/editing paperworks and casenotes does not refresh the page. Instead, a callback is invoked to append the newly created/edited casenote to the component list so that it is rendered.

This PR also made the CaseNoteCard and ParticipantCard functional components. The CaseNoteCard was made functional because state use was basic in the component and making the callback for editing a particular casenote staled the `title` and `description` state for that casenote. Using `componentDidUpdate` or `getDerivedStateFromProps` to unstale the state would've cause additional renders and/or been overkill and complicated, so the component was made functional instead. ParticipantCard was made functional for a similar reason.

## To Test ##
- Simulate casenote/paperwork workflows to make sure that edit/creation works properly.
- If you created the component that I changed, make sure that i didn't accidentally break the component

CC: @didvi