### PR TITLE
Moved hex color codes from style files to utils/theme.js and cleaned unused styles

### DIFF
--- a/app/javascript/components/CaseNoteCard/styles.js
+++ b/app/javascript/components/CaseNoteCard/styles.js
@@ -4,7 +4,7 @@
  * This contains all the styles for the CaseNoteCard container.
  */
 
-export const styles = (/* theme */) => ({
+export const styles = () => ({
   buttonStyle: {
     marginTop: '5px',
     marginBottom: '10px',
@@ -30,21 +30,6 @@ export const styles = (/* theme */) => ({
     overflowX: 'hidden',
     textOverflow: 'ellipsis',
     marginTop: '10px',
-  },
-  MUIRichTextEditorStyle: {
-    border: '5px solid',
-    padding: '10px',
-  },
-  dialogStyle: {
-    padding: '20px',
-  },
-  dialogContentTextStyle: {
-    color: 'black',
-    marginBottom: '2px',
-  },
-  dialogContentTextFieldStyle: {
-    marginTop: '2px',
-    borderStyle: 'solid 4px grey',
   },
 });
 

--- a/app/javascript/components/CaseNoteCardModal/index.js
+++ b/app/javascript/components/CaseNoteCardModal/index.js
@@ -3,33 +3,9 @@ import PropTypes from 'prop-types';
 import MUIRichTextEditor from 'mui-rte';
 import 'draft-js/dist/Draft.css';
 import 'draftail/dist/draftail.css';
-import { withStyles, createMuiTheme } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/core/styles';
 import { Button, Dialog, Grid, Paper } from '@material-ui/core/';
 import styles from './styles';
-
-// TODO: Move to global theme
-const defaultTheme = createMuiTheme();
-Object.assign(defaultTheme, {
-  overrides: {
-    MUIRichTextEditor: {
-      root: {
-        borderLeft: 'solid 1px #C4C4C4',
-        borderRight: 'solid 1px #C4C4C4',
-        borderBottom: 'solid 1px #C4C4C4',
-        borderRadius: '4px',
-        overflow: 'auto',
-      },
-      editorContainer: {
-        padding: '20px',
-        overflow: 'auto',
-        height: '130px',
-      },
-      toolbar: {
-        backgroundColor: '#F4F4F4',
-      },
-    },
-  },
-});
 
 class CaseNoteCardModal extends React.Component {
   constructor(props) {

--- a/app/javascript/components/CaseNoteCardModal/styles.js
+++ b/app/javascript/components/CaseNoteCardModal/styles.js
@@ -1,4 +1,4 @@
-const styles = () => ({
+const styles = theme => ({
   buttonStyle: {
     marginLeft: 'auto',
     marginRight: '0',
@@ -11,7 +11,7 @@ const styles = () => ({
     padding: '20px',
   },
   dialogContentTextStyle: {
-    color: 'black',
+    color: theme.palette.common.black,
     marginBottom: '2px',
   },
   modalItems: {
@@ -21,10 +21,10 @@ const styles = () => ({
     width: '750px',
     height: '100%',
     margin: 'auto',
-    backgroundColor: '#28303B',
+    backgroundColor: theme.palette.common.darkBlue,
   },
   backgroundColor: {
-    backgroundColor: '#28303B',
+    backgroundColor: theme.palette.common.darkBlue,
     padding: '50px',
   },
   caseNoteCardModalDescriptionStyle: {
@@ -32,7 +32,7 @@ const styles = () => ({
     overflow: 'auto',
   },
   titleStyle: {
-    color: 'white',
+    color: theme.palette.common.white,
     fontSize: '36px',
     marginBottom: '0',
     marginTop: '0',

--- a/app/javascript/components/CaseNoteForm/styles.js
+++ b/app/javascript/components/CaseNoteForm/styles.js
@@ -1,6 +1,5 @@
 import { createMuiTheme } from '@material-ui/core/styles';
-
-const grey = '#d2dce1';
+import theme from 'utils/theme';
 
 const styles = () => ({
   dialogActionsStyle: {
@@ -19,7 +18,7 @@ const styles = () => ({
   },
   dialogContentTextFieldStyle: {
     marginTop: '2px',
-    borderStyle: 'solid 4px grey',
+    borderStyle: 'solid',
   },
   primaryButton: {
     border: 'none',
@@ -33,7 +32,7 @@ const styles = () => ({
     lineHeight: '32px',
     borderRadius: '100%',
     textAlign: 'center',
-    backgroundColor: grey,
+    backgroundColor: theme.palette.common.grey,
     marginLeft: '8%',
     boxShadow: '0px 3px 3px rgba(0, 0, 0, 0.25)',
     fontSize: 18,
@@ -46,9 +45,9 @@ Object.assign(defaultTheme, {
   overrides: {
     MUIRichTextEditor: {
       root: {
-        borderLeft: 'solid 1px #C4C4C4',
-        borderRight: 'solid 1px #C4C4C4',
-        borderBottom: 'solid 1px #C4C4C4',
+        borderLeft: `solid 1px ${theme.palette.common.lightGrey}`,
+        borderRight: `solid 1px ${theme.palette.common.lightGrey}`,
+        borderBottom: `solid 1px ${theme.palette.common.lightGrey}`,
         borderRadius: '4px',
       },
       editorContainer: {
@@ -57,7 +56,7 @@ Object.assign(defaultTheme, {
         height: '130px',
       },
       toolbar: {
-        backgroundColor: '#F4F4F4',
+        backgroundColor: theme.palette.common.lightestGrey,
       },
     },
   },

--- a/app/javascript/components/DeleteModal/index.js
+++ b/app/javascript/components/DeleteModal/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import { apiDelete } from 'utils/axios';
 import 'draft-js/dist/Draft.css';
@@ -46,9 +47,10 @@ class DeleteModal extends React.Component {
   }
 
   render() {
+    const { classes } = this.props;
     const dialog = (
       <Dialog
-        style={styles.dialogStyle}
+        className={classes.dialogStyle}
         open={this.state.open}
         onClose={this.handleClose}
         aria-labelledby="form-dialog-title"
@@ -56,22 +58,22 @@ class DeleteModal extends React.Component {
         fullWidth
       >
         <DialogContent maxwidth="sm">
-          <DialogContentText style={styles.dialogContentTextStyle}>
+          <DialogContentText className={classes.dialogContentTextStyle}>
             {this.state.message}
           </DialogContentText>
         </DialogContent>
 
-        <DialogActions style={styles.dialogActionsStyle}>
+        <DialogActions className={classes.dialogActionsStyle}>
           <Button
             onClick={this.handleClose}
-            variant="outlined"
+            variant="contained"
             color="secondary"
           >
             Cancel
           </Button>
           <Button
             onClick={this.handleSubmit}
-            variant="outlined"
+            variant="contained"
             color="primary"
           >
             Delete
@@ -89,9 +91,10 @@ class DeleteModal extends React.Component {
 }
 
 DeleteModal.propTypes = {
+  classes: PropTypes.object.isRequired,
   body: PropTypes.object.isRequired,
   req: PropTypes.string.isRequired,
   message: PropTypes.string,
 };
 
-export default DeleteModal;
+export default withStyles(styles)(DeleteModal);

--- a/app/javascript/components/DeleteModal/styles.js
+++ b/app/javascript/components/DeleteModal/styles.js
@@ -1,4 +1,4 @@
-const styles = () => ({
+const styles = theme => ({
   dialogActionsStyle: {
     padding: '30px',
   },
@@ -10,7 +10,7 @@ const styles = () => ({
     padding: '20px',
   },
   dialogContentTextStyle: {
-    color: 'black',
+    color: theme.palette.common.black,
     marginBottom: '2px',
   },
 });

--- a/app/javascript/components/Login/styles.js
+++ b/app/javascript/components/Login/styles.js
@@ -1,4 +1,4 @@
-const styles = () => ({
+const styles = theme => ({
   body: {
     margin: 0,
   },
@@ -10,7 +10,7 @@ const styles = () => ({
   },
 
   background: {
-    background: 'rgb(41, 49, 60)',
+    background: theme.palette.common.black,
     margin: -10,
     padding: -10,
   },
@@ -22,7 +22,7 @@ const styles = () => ({
   },
 
   loginContainer: {
-    background: 'rgb(41, 49, 60)',
+    background: theme.palette.common.black,
     margin: 0,
     display: 'flex',
     alignContent: 'center',

--- a/app/javascript/components/Navbar/styles.js
+++ b/app/javascript/components/Navbar/styles.js
@@ -8,7 +8,7 @@ const styles = theme => ({
   navBar: {
     height: '100vh',
     paddingTop: 40,
-    backgroundColor: '#29313C',
+    backgroundColor: theme.palette.common.black,
     position: 'fixed',
   },
   drawer: {
@@ -27,7 +27,7 @@ const styles = theme => ({
     width: '100%',
     objectFit: 'contain',
     overflowX: 'hidden',
-    backgroundColor: '#29313C',
+    backgroundColor: theme.palette.common.black,
   },
 });
 

--- a/app/javascript/components/PaperworkEntry/styles.js
+++ b/app/javascript/components/PaperworkEntry/styles.js
@@ -7,7 +7,7 @@
 const styles = theme => ({
   card: {
     borderBottom: ({ lastEntry }) =>
-      lastEntry ? '0px' : `.75px solid ${theme.palette.grey[400]}`,
+      lastEntry ? '0px' : `.75px solid ${theme.palette.common.lightGrey}`,
     borderRadius: 0,
     boxShadow: '0px 0px 0px 0px',
     backgroundColor: 'inherit',

--- a/app/javascript/components/PaperworkForm/styles.js
+++ b/app/javascript/components/PaperworkForm/styles.js
@@ -4,8 +4,6 @@
  * This contains all the styles for the PaperworkForm component.
  */
 
-const grey = '#d2dce1';
-
 const styles = theme => ({
   dialogActions: {
     padding: '30px',
@@ -25,7 +23,7 @@ const styles = theme => ({
   },
   textField: {
     marginTop: 2,
-    borderStyle: 'solid 4px grey',
+    borderStyle: 'solid',
   },
   textFieldBorder: {
     borderRadius: 0,
@@ -35,7 +33,7 @@ const styles = theme => ({
     height: 32,
     borderRadius: '100%',
     textAlign: 'center',
-    backgroundColor: grey,
+    backgroundColor: theme.palette.common.grey,
     marginLeft: '8%',
     boxShadow: '0px 3px 3px rgba(0, 0, 0, 0.25)',
     fontSize: 18,

--- a/app/javascript/components/ParticipantCard/index.js
+++ b/app/javascript/components/ParticipantCard/index.js
@@ -10,7 +10,6 @@ import {
   faTimes,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import theme from 'utils/theme';
 import styles from './styles';
 
 function ParticipantCard({ classes, participant }) {
@@ -42,16 +41,6 @@ function ParticipantCard({ classes, participant }) {
     ></FontAwesomeIcon>
   );
 
-  let statusColor;
-  const status = participant.status.toUpperCase();
-  if (status === 'R0') {
-    statusColor = theme.palette.primary.light;
-  } else if (status === 'R1') {
-    statusColor = '#5870EB';
-  } else {
-    statusColor = '#DF6C8E';
-  }
-
   const caseNotes =
     numCaseNotes === 1
       ? `${numCaseNotes} case note`
@@ -68,12 +57,7 @@ function ParticipantCard({ classes, participant }) {
         {participant.name}
       </td>
       <td>
-        <div
-          className={classes.status}
-          style={{ backgroundColor: statusColor }}
-        >
-          {status}
-        </div>
+        <div className={classes.status}>{participant.status.toUpperCase()}</div>
       </td>
       <td className={classes.newAssignment}>
         <div>

--- a/app/javascript/components/ParticipantCard/index.js
+++ b/app/javascript/components/ParticipantCard/index.js
@@ -46,11 +46,11 @@ class ParticipantCard extends React.Component {
 
     let statusColor;
     if (status === 'R0') {
-      statusColor = theme.palette.primary.light;
+      statusColor = theme.palette.common.r0;
     } else if (status === 'R1') {
-      statusColor = '#5870EB';
+      statusColor = theme.palette.common.r1;
     } else {
-      statusColor = '#DF6C8E';
+      statusColor = theme.palette.common.r2;
     }
     const caseNotes =
       p.caseNotesCount === 1
@@ -67,13 +67,18 @@ class ParticipantCard extends React.Component {
           {name}
         </td>
         <td>
-          <div className={classes.status} style={{ backgroundColor: statusColor }}>
+          <div
+            className={classes.status}
+            style={{ backgroundColor: statusColor }}
+          >
             {status}
           </div>
         </td>
         <td className={classes.newAssignment}>
           <div>
-            <div className={classes.paperworkText}>{p.paperworksCompleted} / {p.paperworksCount} completed </div>
+            <div className={classes.paperworkText}>
+              {p.paperworksCompleted} / {p.paperworksCount} completed{' '}
+            </div>
             <PaperworkForm
               display="plus"
               type="create"

--- a/app/javascript/components/ParticipantCard/styles.js
+++ b/app/javascript/components/ParticipantCard/styles.js
@@ -1,4 +1,4 @@
-const styles = () => ({
+const styles = theme => ({
   iconLarge: {
     width: 35,
     height: 35,
@@ -9,10 +9,10 @@ const styles = () => ({
     maxWidth: 80,
   },
   r0Color: {
-    backgroundColor: '#009FAD',
+    backgroundColor: theme.palette.common.r0,
   },
   r1Color: {
-    backgroundColor: '#5870EB',
+    backgroundColor: theme.palette.common.r1,
   },
   status: {
     width: 52,
@@ -21,7 +21,7 @@ const styles = () => ({
     textAlign: 'center',
     verticalAlign: 'middle',
     lineHeight: '52px',
-    color: '#fff',
+    color: theme.palette.common.white,
   },
   newAssignment: {
     '& > div': {

--- a/app/javascript/components/ParticipantCard/styles.js
+++ b/app/javascript/components/ParticipantCard/styles.js
@@ -22,6 +22,19 @@ const styles = theme => ({
     verticalAlign: 'middle',
     lineHeight: '52px',
     color: theme.palette.common.white,
+    backgroundColor: ({ participant }) => {
+      switch (participant.status.toUpperCase()) {
+        case 'R0':
+          return theme.palette.common.r0;
+        case 'R1':
+          return theme.palette.common.r1;
+        case 'R2':
+          return theme.palette.common.r2;
+        default:
+          console.error('Participant has no status');
+          return theme.palette.common.black;
+      }
+    },
   },
   newAssignment: {
     '& > div': {

--- a/app/javascript/components/ParticipantShowPage/styles.js
+++ b/app/javascript/components/ParticipantShowPage/styles.js
@@ -30,7 +30,19 @@ const styles = theme => ({
   avatarStyle: {
     width: 60,
     height: 60,
-    backgroundColor: theme.palette.common.r1,
+    backgroundColor: ({ status }) => {
+      switch (status.toUpperCase()) {
+        case 'R0':
+          return theme.palette.common.r0;
+        case 'R1':
+          return theme.palette.common.r1;
+        case 'R2':
+          return theme.palette.common.r2;
+        default:
+          console.error('Participant has no status');
+          return theme.palette.common.black;
+      }
+    },
   },
   unloopLogo: {
     paddingLeft: '10px',

--- a/app/javascript/components/ParticipantShowPage/styles.js
+++ b/app/javascript/components/ParticipantShowPage/styles.js
@@ -30,7 +30,7 @@ const styles = theme => ({
   avatarStyle: {
     width: 60,
     height: 60,
-    backgroundColor: '#EB6658',
+    backgroundColor: theme.palette.common.r1,
   },
   unloopLogo: {
     paddingLeft: '10px',

--- a/app/javascript/components/QuestionnaireForm/styles.js
+++ b/app/javascript/components/QuestionnaireForm/styles.js
@@ -4,10 +4,7 @@
  * This contains all the styles for the QuestionnaireForm container.
  */
 
-const styles = (/* theme */) => ({
-  root: {
-    backgroundColor: '#000000',
-  },
+const styles = () => ({
   dialogActions: {
     padding: 30,
   },
@@ -18,8 +15,8 @@ const styles = (/* theme */) => ({
     width: '100%',
   },
   dialogContentTextField: {
-    marginTop: 2,
-    borderStyle: 'solid 4px grey',
+    marginTop: 8,
+    borderStyle: 'solid',
   },
   questionnaireEntry: {
     marginBottom: 20,

--- a/app/javascript/components/QuestionnaireView/index.js
+++ b/app/javascript/components/QuestionnaireView/index.js
@@ -12,7 +12,6 @@ import { DialogContent, Grid, Typography } from '@material-ui/core';
 import styles from './styles';
 
 function QuestionnaireView({ classes, questionnaire }) {
-  // console.log(questionnaire)
   const renderField = (title, body) => {
     if (title === 'id' || title === 'participant') {
       return null;

--- a/app/javascript/components/QuestionnaireView/styles.js
+++ b/app/javascript/components/QuestionnaireView/styles.js
@@ -4,7 +4,7 @@
  * This contains all the styles for the QuestionnaireView component.
  */
 
-const styles = (/* theme */) => ({
+const styles = () => ({
   field: {
     padding: '12px 90px',
     textTransform: 'capitalize',

--- a/app/javascript/components/StaffDashboard/styles.js
+++ b/app/javascript/components/StaffDashboard/styles.js
@@ -1,7 +1,4 @@
-const backgroundBlue = '#d2dce1';
-const white = '#fff';
-
-const styles = () => ({
+const styles = theme => ({
   dashboard: {
     height: '100%',
     width: '100%',
@@ -11,7 +8,7 @@ const styles = () => ({
       '& th': {
         paddingBottom: 16,
       },
-      borderBottom: '2px solid #eb6658',
+      borderBottom: `2px solid ${theme.palette.secondary.main}`,
     },
     '& h1': {
       marginLeft: 50,
@@ -51,12 +48,12 @@ const styles = () => ({
       '& th, & td': {
         padding: '25px 3%',
         textAlign: 'left',
-        borderBottom: '1px solid #ddd',
+        borderBottom: `1px solid ${theme.palette.common.lightGrey}`,
       },
 
       '& tbody': {
         '& tr:hover': {
-          backgroundColor: '#f5f5f5',
+          backgroundColor: theme.palette.common.lightestGrey,
         },
       },
 
@@ -72,10 +69,10 @@ const styles = () => ({
   tableContainer: {
     height: '100%',
     minHeight: '100vh',
-    backgroundColor: backgroundBlue,
+    backgroundColor: theme.palette.common.grey,
     padding: '20px 42px',
     '& > div': {
-      backgroundColor: white,
+      backgroundColor: theme.palette.common.white,
       boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.25)',
       borderRadius: 20,
       padding: 30,
@@ -92,7 +89,7 @@ const styles = () => ({
     marginLeft: 30,
     borderRadius: 2,
     width: 260,
-    border: '1px solid #bdbdbd',
+    border: `1px solid ${theme.palette.common.lightGrey}`,
     paddingLeft: 10,
     display: 'flex',
     flexDirection: 'row',

--- a/app/javascript/utils/theme.js
+++ b/app/javascript/utils/theme.js
@@ -11,9 +11,9 @@ export const theme = createMuiTheme({
       grey: '#d2dce1',
       lightGrey: '#C4C4C4',
       lightestGrey: '#F4F4F4',
-      r0: '#009FAD',
-      r1: '#5870EB',
-      r2: '#DF6C8E',
+      r0: '#5870EB',
+      r1: 'rgba(235, 102, 88, 0.5)',
+      r2: 'rgba(0, 159, 173, 0.5)',
     },
     primary: {
       light: '#009FAD',

--- a/app/javascript/utils/theme.js
+++ b/app/javascript/utils/theme.js
@@ -5,8 +5,15 @@ export const theme = createMuiTheme({
     common: {
       blue: '#187be5',
       lightBlue: 'rgba(210, 220, 225, 0.63)',
+      darkBlue: '#28303B',
       black: '#29313C',
       white: '#FFFFFF',
+      grey: '#d2dce1',
+      lightGrey: '#C4C4C4',
+      lightestGrey: '#F4F4F4',
+      r0: '#009FAD',
+      r1: '#5870EB',
+      r2: '#DF6C8E',
     },
     primary: {
       light: '#009FAD',


### PR DESCRIPTION
PR does what title says. No longer WIP.

## How to review:
Go through the app and make sure colors look fine! There were a bunch of slightly-off greys that I blended together like `#f5f5f5` and `#f4f4f4` hopefully thats ok/not noticeable but if it is let me know and I can change it back.

## To do after:
There's some styling-related code in `ParticipantCard`'s `index.js` that I'd like to move to `styles.js` but I want to do that after [this PR](https://github.com/calblueprint/unloop/pull/68) gets merged in because that changes `ParticipantCard` from class to functional and I want to avoid potential merge conflicts.

CC: @didvi