### PR TITLE
Only be able to delete action items without assignments attached to them

### DIFF
--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -79,10 +79,10 @@ class Api::AssignmentsController < ApplicationController
 
     def destroy_template
         authorize @template, :destroy?
-        if @template.destroy
+        if @template.is_template && @template.destroy
             render json: @template, status: :ok
         else
-            render json: { error: 'Failed to delete action item template' }, status: :unprocessable_entity
+            render json: { error: 'Failed to delete action item template. Action item must be a template.' }, status: :unprocessable_entity
         end
     end
 

--- a/app/models/action_item.rb
+++ b/app/models/action_item.rb
@@ -1,5 +1,5 @@
 class ActionItem < ApplicationRecord
-    has_many :assignments, dependent: :restrict_with_error
+    has_many :assignments, dependent: :destroy
 
     validates :title, :description, presence: true
     validates :is_template, inclusion: [true, false]

--- a/app/models/action_item.rb
+++ b/app/models/action_item.rb
@@ -1,5 +1,5 @@
 class ActionItem < ApplicationRecord
-    has_many :assignments, dependent: :destroy
+    has_many :assignments, dependent: :restrict_with_error
 
     validates :title, :description, presence: true
     validates :is_template, inclusion: [true, false]


### PR DESCRIPTION
PR does what title says. This functionality was mentioned in the merged PR [here](https://github.com/calblueprint/unloop/pull/64).

Didn't place a `dependent: :restrict_with_error` attribute on `ActionItem` since `dependent: :destroy` functionality is used in the create function when an error occurs. 

CC: @didvi