### PR TITLE
Action Items copy on update

### DIFF
--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -32,7 +32,17 @@ class Api::AssignmentsController < ApplicationController
 
     def update
         authorize @assignment
-        if @assignment.update(assignment_params) && @assignment.action_item.update(action_item_params)
+        if !action_item_params.empty?
+            # Need to only copy if multiple assignments pointing
+            @action_item = @assignment.action_item.dup
+            @action_item.assign_attributes(action_item_params)
+            if @action_item.save
+                @assignment.update(action_item: @action_item)
+            else
+                render json: { error: 'Could not update action item' }, status: :unprocessable_entity
+            end
+        end
+        if @assignment.update(assignment_params)
             render json: @assignment, status: :ok
         else
             render json: { error: 'Could not update action item' }, status: :unprocessable_entity

--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -32,17 +32,20 @@ class Api::AssignmentsController < ApplicationController
 
     def update
         authorize @assignment
-        if !action_item_params.empty?
-            # Need to only copy if multiple assignments pointing
-            @action_item = @assignment.action_item.dup
-            @action_item.assign_attributes(action_item_params)
-            if @action_item.save
-                @assignment.update(action_item: @action_item)
-            else
-                render json: { error: 'Could not update action item' }, status: :unprocessable_entity
-            end
+        action_item_copied = false
+        action_item = @assignment.action_item
+
+        if !action_item_params.empty? && action_item.assignments.length > 1
+            action_item = action_item.dup
+            action_item_copied = true
         end
-        if @assignment.update(assignment_params)
+
+        @assignment.assign_attributes(assignment_params)
+        action_item.assign_attributes(action_item_params)
+        if (action_item.valid? && @assignment.valid?) && (action_item.save && @assignment.save)
+            if action_item_copied
+                @assignment.update(action_item: action_item)
+            end
             render json: @assignment, status: :ok
         else
             render json: { error: 'Could not update action item' }, status: :unprocessable_entity
@@ -122,7 +125,7 @@ class Api::AssignmentsController < ApplicationController
 
     def action_item_params
         action_item_param = params.require(:assignment).permit(:title,
-                                                                :description)
+                                                               :description)
     end
 
     def assigned_to_ids

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -5,7 +5,7 @@ class Assignment < ApplicationRecord
     
     validates :action_item, :assigned_by, :assigned_to, presence: true
     validates :completed, inclusion: [true, false]
-    validate :nontemplate_assignment, on: :create
+    validate :nontemplate_assignment, on: [:create, :update, :save]
 
     def cond_assignment_title
         action_item.title unless action_item.nil?


### PR DESCRIPTION
Previously, if an action item assigned to mulitple people were edited (ex: a title change), it would edit for all people instead of just one. Now, only the edited assignment will have its action item contents changed.

CC: @didvi