### PR TITLE
[Easy] Added categories to action items

### DIFF
--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -168,11 +168,12 @@ class Api::AssignmentsController < ApplicationController
 
     def action_item_params
         action_item_param = params.require(:assignment).permit(:title,
-                                                               :description)
+                                                               :description,
+                                                               :category)
     end
 
     def bulk_assignment_params
-        all_assignment_params = params.permit(assignments: [:title, :description, :due_date], assigned_to_ids: [])
+        all_assignment_params = params.permit(assignments: [:title, :description, :due_date, :category], assigned_to_ids: [])
      end
 
     def assignment_params

--- a/app/models/action_item.rb
+++ b/app/models/action_item.rb
@@ -1,6 +1,8 @@
 class ActionItem < ApplicationRecord
     has_many :assignments, dependent: :destroy
 
-    validates :title, :description, presence: true
+    validates :title, :description, :category, presence: true
     validates :is_template, inclusion: [true, false]
+
+    enum category: {Finances: 0, Project: 1, Community: 2, Startup: 3, Treatment: 4, Health: 5, Education: 6}
 end

--- a/db/migrate/20200413091115_add_category_to_action_items.rb
+++ b/db/migrate/20200413091115_add_category_to_action_items.rb
@@ -1,0 +1,5 @@
+class AddCategoryToActionItems < ActiveRecord::Migration[6.0]
+  def change
+    add_column :action_items, :category, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_30_025821) do
+ActiveRecord::Schema.define(version: 2020_04_13_091115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_03_30_025821) do
     t.boolean "is_template", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "category"
   end
 
   create_table "assignments", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -76,6 +76,7 @@ def create_template_action_items
   1.upto(NUM_TEMPLATE_ACTION_ITEMS) do |i|
     ActionItem.create(title: Faker::Hacker.noun,
                       description: Faker::Hacker.say_something_smart,
+                      category: Faker::Number.between(from: 0, to: ActionItem.categories.length - 1),
                       is_template: true,
                     )
   end
@@ -86,6 +87,7 @@ def create_assignments
   1.upto(NUM_ACTION_ITEMS) do |i|
     action_item = ActionItem.create!(title: Faker::Hacker.noun, 
                                      description: Faker::Hacker.say_something_smart,
+                                     category: Faker::Number.between(from: 0, to: ActionItem.categories.length - 1),
                                      is_template: false,
                                     )
     1.upto(rand(1...4)) do |i|


### PR DESCRIPTION
Categories wasn't previously a column for Action Item. This PR fixes that. Please double check my work  because I did this pretty quickly and I've never migrated an enum (I based it off `User.user_type` since that was also an enum). 

I need this PR to get merged to fully test my AddFromExistingModal so a bit urgent (that PR almost done as well)!
 

CC: @didvi