### PR TITLE
Some styling tweaks

### DIFF
--- a/app/javascript/components/CaseNoteCard/index.js
+++ b/app/javascript/components/CaseNoteCard/index.js
@@ -78,29 +78,27 @@ function CaseNoteCard({
   );
 
   return (
-    <Grid container spacing={3}>
-      <Grid item xs={11}>
-        <Paper className={classes.caseNoteCardStyle}>
-          <Grid container spacing={2}>
-            <Grid item xs={10}>
-              <h3 className={classes.casenoteCardTitleStyle}>{title}</h3>
-            </Grid>
-            <Grid item xs={2}>
-              {showMenu ? renderMenuItems() : null}
-            </Grid>
+    <Grid item>
+      <Paper className={classes.caseNoteCardStyle}>
+        <Grid container spacing={2}>
+          <Grid item xs={10}>
+            <h3 className={classes.casenoteCardTitleStyle}>{title}</h3>
           </Grid>
-          <div className={classes.caseNoteDescStyle}>
-            <MUIRichTextEditor value={description} readOnly toolbar={false} />
-          </div>
+          <Grid item xs={2}>
+            {showMenu ? renderMenuItems() : null}
+          </Grid>
+        </Grid>
+        <div className={classes.caseNoteDescStyle}>
+          <MUIRichTextEditor value={description} readOnly toolbar={false} />
+        </div>
 
-          <Grid container spacing={2} className={classes.buttonStyle}>
-            <Grid item xs={8}></Grid>
-            <Grid item xs={4}>
-              <CaseNoteCardModal description={description} title={title} />
-            </Grid>
+        <Grid container spacing={2} className={classes.buttonStyle}>
+          <Grid item xs={8}></Grid>
+          <Grid item xs={4}>
+            <CaseNoteCardModal description={description} title={title} />
           </Grid>
-        </Paper>
-      </Grid>
+        </Grid>
+      </Paper>
     </Grid>
   );
 }

--- a/app/javascript/components/CaseNoteCard/styles.js
+++ b/app/javascript/components/CaseNoteCard/styles.js
@@ -4,17 +4,17 @@
  * This contains all the styles for the CaseNoteCard container.
  */
 
-export const styles = () => ({
+export const styles = theme => ({
   buttonStyle: {
     marginTop: '5px',
     marginBottom: '10px',
   },
   caseNoteCardStyle: {
-    marginLeft: '20px',
     padding: '20px',
     boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.15)',
-    borderRadius: '10px',
+    borderRadius: theme.shape.borderRadius,
     height: '240px',
+    marginTop: '20px',
   },
   caseNoteDescStyle: {
     height: '105px',

--- a/app/javascript/components/CaseNoteContainer/index.js
+++ b/app/javascript/components/CaseNoteContainer/index.js
@@ -119,7 +119,6 @@ class CaseNoteContainer extends React.Component {
                   justify="space-between"
                   style={{
                     borderBottom: '5px solid #EB6658',
-                    marginBottom: '25px',
                   }}
                 >
                   <Grid item xs={4}>

--- a/app/javascript/components/PaperworkList/styles.js
+++ b/app/javascript/components/PaperworkList/styles.js
@@ -7,7 +7,7 @@
 const styles = theme => ({
   containerStyle: {
     padding: '18px 28px',
-    borderRadius: 10,
+    borderRadius: theme.shape.borderRadius,
     marginLeft: 0,
     marginRight: 0,
   },

--- a/app/javascript/components/ParticipantShowPage/index.js
+++ b/app/javascript/components/ParticipantShowPage/index.js
@@ -80,7 +80,7 @@ class ParticipantShowPage extends React.Component {
               item
               container
               direction="row"
-              justify="space-evenly"
+              justify="flex-start"
               spacing={1}
             >
               <Grid item>

--- a/app/javascript/components/StudioAssessmentList/styles.js
+++ b/app/javascript/components/StudioAssessmentList/styles.js
@@ -7,7 +7,7 @@
 const styles = theme => ({
   containerStyle: {
     padding: '18px 28px',
-    borderRadius: 10,
+    borderRadius: theme.shape.borderRadius,
     marginLeft: 0,
     marginRight: 0,
   },

--- a/app/javascript/components/styles.js
+++ b/app/javascript/components/styles.js
@@ -55,7 +55,6 @@ export const styles = () => ({
     height: '30px',
     display: 'flex',
     alignItems: 'center',
-    // alignContent: 'space-between',
     justifyContent: 'space-between',
     width: '100%',
   },


### PR DESCRIPTION
Tweaks:
- Made action item card wider so that it is not off center 
- Made border radius of all list components on participant page the same as the staff dashboard
- Changed the spacing of the questionnaire buttons to be inline with the name
- Changed the spacing for the orange header of case  notes so it is not cutoff at a strange spot

Let me know if these are improvements or not, I'm not sure if the case  note width is better or worse, or if you would prefer the more rounded boxes or not. @joelenelatief 

Before:
![image](https://user-images.githubusercontent.com/41552318/80230186-6d4e5f80-8606-11ea-8568-f3f6d8ae0a17.png)

After:
![image](https://user-images.githubusercontent.com/41552318/80230206-75a69a80-8606-11ea-8b85-8eef501f04a5.png)


Scroll behavior before
![image](https://user-images.githubusercontent.com/41552318/80230238-822af300-8606-11ea-85cb-ef842b5b82c2.png)


Scroll behavior after
![image](https://user-images.githubusercontent.com/41552318/80230272-94a52c80-8606-11ea-8d25-4f93fd04d512.png)




