### PR TITLE
Selecting template action item pops up modal to choose date

### DIFF
--- a/app/javascript/components/AddFromExistingForm/index.js
+++ b/app/javascript/components/AddFromExistingForm/index.js
@@ -5,6 +5,11 @@ import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 import Fab from '@material-ui/core/Fab';
+import Button from '@material-ui/core/Button';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
 import Paper from '@material-ui/core/Paper';
 import ActionItemCard from 'components/ActionItemCard';
 import theme from 'utils/theme';
@@ -17,10 +22,18 @@ class AddFromExistingForm extends React.Component {
     super(props);
     this.state = {
       actionItemTemplates: this.props.templates,
+      selectedActionItem: null,
+      selectedActionItemDate: '',
       categorySelected: null,
     };
     this.selectCategory = this.selectCategory.bind(this);
     this.filterActionItems = this.filterActionItems.bind(this);
+    this.handleCloseDateModal = this.handleCloseDateModal.bind(this);
+    this.handleOpenDateModal = this.handleOpenDateModal.bind(this);
+    this.handleSubmitSelectedTemplateActionItem = this.handleSubmitSelectedTemplateActionItem.bind(
+      this,
+    );
+    this.handleDateChange = this.handleDateChange.bind(this);
   }
 
   componentDidMount() {
@@ -31,10 +44,11 @@ class AddFromExistingForm extends React.Component {
     });
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.templates.length !== prevProps.templates.length) {
-      this.setState({ actionItemTemplates: this.props.templates });
+  static getDerivedStateFromProps(props, state) {
+    if (props.templates.length !== state.actionItemTemplates.length) {
+      return { actionItemTemplates: props.templates };
     }
+    return {};
   }
 
   selectCategory(categorySelected) {
@@ -43,6 +57,29 @@ class AddFromExistingForm extends React.Component {
     } else {
       this.setState({ categorySelected });
     }
+  }
+
+  handleCloseDateModal() {
+    this.setState({
+      selectedActionItem: null,
+      selectedActionItemDate: '',
+    });
+  }
+
+  /* When called, modal appears to choose due date for the action item passed in */
+  handleOpenDateModal(actionItem) {
+    this.setState({ selectedActionItem: actionItem });
+  }
+
+  handleSubmitSelectedTemplateActionItem() {
+    this.state.selectedActionItem.dueDate = this.state.selectedActionItemDate;
+    this.props.selectActionItemTemplate(this.state.selectedActionItem);
+    this.handleCloseDateModal();
+  }
+
+  handleDateChange(event) {
+    const { value } = event.target;
+    this.setState({ selectedActionItemDate: value });
   }
 
   filterActionItems(e) {
@@ -80,7 +117,7 @@ class AddFromExistingForm extends React.Component {
             handleIconClick={
               selected
                 ? () => this.props.removeSelectedActionItem(template)
-                : () => this.props.selectActionItemTemplate(template)
+                : () => this.handleOpenDateModal(template)
             }
             lastEntry={filteredTemplates.length - 1 === i}
             removeActionItem={() => this.props.deleteTemplate(template)}
@@ -133,6 +170,28 @@ class AddFromExistingForm extends React.Component {
 
     return (
       <ThemeProvider theme={theme}>
+        <Dialog
+          open={this.state.selectedActionItem !== null}
+          onClose={this.handleCloseDateModal}
+        >
+          <DialogTitle> Choose a due date (optional) </DialogTitle>
+          <DialogContent>
+            <TextField
+              type="date"
+              value={this.state.selectedActionItemDate}
+              fullWidth
+              onChange={e => this.handleDateChange(e)}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={this.handleSubmitSelectedTemplateActionItem}
+              color="primary"
+            >
+              Create Assignment
+            </Button>
+          </DialogActions>
+        </Dialog>
         <Paper elevation={3} className={classes.formStyle}>
           <Grid container spacing={1} direction="column">
             <Grid item container direction="column" spacing={1}>

--- a/app/javascript/components/AddFromExistingForm/index.js
+++ b/app/javascript/components/AddFromExistingForm/index.js
@@ -44,11 +44,10 @@ class AddFromExistingForm extends React.Component {
     });
   }
 
-  static getDerivedStateFromProps(props, state) {
-    if (props.templates.length !== state.actionItemTemplates.length) {
-      return { actionItemTemplates: props.templates };
+  componentDidUpdate(prevProps) {
+    if (this.props.templates.length !== prevProps.templates.length) {
+      this.setState({ actionItemTemplates: this.props.templates });
     }
-    return {};
   }
 
   selectCategory(categorySelected) {


### PR DESCRIPTION
As title says. Popup is optional. If you click out of the modal, the selection is cancelled. If you click "create assignment" without choosing a date then no date is chosen. Dates chosen don't persist, so if you choose date, click out of popup, and open popup again, you have to choose the date again.

Let me know if there's anything that should be changed (or if there's a better way to do this). Also don't know if "Create Assignment" is the most appropriate wording.

## To test:
Pull and try to break.


### Screenshots

![image](https://user-images.githubusercontent.com/35501399/80448358-df59c980-88d0-11ea-8ac1-a74894e7fd62.png)


Optional but would be nice for final presentation :)


CC: @didvi