### PR TITLE
Fixed bug with creating new creating new template action item then na…

### DIFF
--- a/app/javascript/components/ActionItemCreationContainer/index.js
+++ b/app/javascript/components/ActionItemCreationContainer/index.js
@@ -17,7 +17,7 @@ const Setting = {
 function ActionItemCreationContainer({
   classes,
   templates,
-  selectedActionItems,
+  selectedActionItemIds,
   title,
   setTitle,
   description,
@@ -101,7 +101,7 @@ function ActionItemCreationContainer({
           ) : (
             <AddFromExistingForm
               templates={templates}
-              selectedActionItems={selectedActionItems}
+              selectedActionItemIds={selectedActionItemIds}
               selectActionItemTemplate={selectActionItemTemplate}
               removeSelectedActionItem={removeSelectedActionItem}
               deleteTemplate={deleteTemplate}
@@ -116,7 +116,7 @@ function ActionItemCreationContainer({
 ActionItemCreationContainer.propTypes = {
   classes: PropTypes.object.isRequired,
   templates: PropTypes.array.isRequired,
-  selectedActionItems: PropTypes.instanceOf(Set).isRequired,
+  selectedActionItemIds: PropTypes.instanceOf(Set).isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   dueDate: PropTypes.string.isRequired,

--- a/app/javascript/components/AddFromExistingForm/index.js
+++ b/app/javascript/components/AddFromExistingForm/index.js
@@ -69,7 +69,7 @@ class AddFromExistingForm extends React.Component {
     );
 
     filteredTemplates = filteredTemplates.map((template, i) => {
-      const selected = this.props.selectedActionItems.has(template);
+      const selected = this.props.selectedActionItemIds.has(template.id);
       return (
         <Grid item key={template.id}>
           <ActionItemCard
@@ -180,7 +180,7 @@ class AddFromExistingForm extends React.Component {
 AddFromExistingForm.propTypes = {
   classes: PropTypes.object.isRequired,
   templates: PropTypes.array.isRequired,
-  selectedActionItems: PropTypes.instanceOf(Set).isRequired,
+  selectedActionItemIds: PropTypes.instanceOf(Set).isRequired,
   selectActionItemTemplate: PropTypes.func.isRequired,
   removeSelectedActionItem: PropTypes.func.isRequired,
   deleteTemplate: PropTypes.func.isRequired,


### PR DESCRIPTION
Before, newly created templates would not show up in the template list in "See Common Assignments" until the user refreshed. Now, when a user creates a new template, the newly created template should behave exactly like the preexisting templates (checkmark, delete should work, etc...).

## NOTE:
If the "add to common assignments" button is checked but the API call to create the template fails, the action item created will act identical to a regular action item (ie: it'll behave as if the action item created never had the "add to common assignments" checked). Most notably, this means that the card will not show up as a template in the "AddFromExisting" component.


CC: @didvi