### PR TITLE
Added x at top right of ActionItemCard and fixed small styling issues

### DIFF
--- a/app/javascript/components/ActionItemCard/index.js
+++ b/app/javascript/components/ActionItemCard/index.js
@@ -3,6 +3,7 @@ import { withStyles, ThemeProvider } from '@material-ui/core/styles';
 import IconButton from '@material-ui/core/IconButton';
 import AddIcon from '@material-ui/icons/Add';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import CloseIcon from '@material-ui/icons/Close';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
@@ -18,6 +19,7 @@ function ActionItemCard({
   dueDate,
   category,
   selected,
+  renderClose,
   // Used by style file
   // eslint-disable-next-line no-unused-vars
   lastEntry = false,
@@ -30,6 +32,22 @@ function ActionItemCard({
     </IconButton>
   );
 
+  const renderCloseIcon = () => (
+    <IconButton aria-label="close" onClick={removeActionItem}>
+      <CloseIcon style={{ fontSize: 'medium' }} />
+    </IconButton>
+  );
+
+  const renderDeleteButton = () => (
+    <Button
+      size="small"
+      className={classes.buttonStyle}
+      onClick={removeActionItem}
+    >
+      DELETE
+    </Button>
+  );
+
   return (
     <ThemeProvider theme={theme}>
       <Grid
@@ -39,29 +57,42 @@ function ActionItemCard({
         direction="column"
         justify="space-evenly"
       >
-        <Grid item container alignItems="center" spacing={2}>
-          <Grid item>
-            <Typography variant="subtitle1"> {title} </Typography>
-          </Grid>
-          <Grid item>
-            <Fab
-              className={classes.iconStyle}
-              component="span"
-              variant="extended"
-              size="small"
-              aria-label="category"
-            >
-              <Typography
-                className={classes.categoryButtonStyle}
-                color="primary"
-                align="center"
-              >
-                {category ? category.toUpperCase() : category}
+        <Grid
+          item
+          container
+          alignItems="center"
+          justify="space-between"
+          wrap="nowrap"
+          spacing={2}
+        >
+          <Grid item container alignItems="center" wrap="nowrap">
+            <Grid item className={classes.titleStyle}>
+              <Typography variant="subtitle1" noWrap>
+                {' '}
+                {title}{' '}
               </Typography>
-            </Fab>
+            </Grid>
+            <Grid item>
+              <Fab
+                className={classes.iconStyle}
+                component="span"
+                variant="extended"
+                size="small"
+                aria-label="category"
+              >
+                <Typography
+                  className={classes.categoryButtonStyle}
+                  color="primary"
+                  align="center"
+                >
+                  {category ? category.toUpperCase() : category}
+                </Typography>
+              </Fab>
+            </Grid>
           </Grid>
+          <Grid item>{renderClose ? renderCloseIcon() : null}</Grid>
         </Grid>
-        <Grid item container alignItems="flex-start" spacing={6}>
+        <Grid item container alignItems="center" spacing={6}>
           <Grid item xs={9} className={classes.descriptionStyle}>
             <Typography variant="body1" style={{ fontSize: '14px' }}>
               {description}
@@ -88,15 +119,7 @@ function ActionItemCard({
                 EDIT
               </Button>
             </Grid> */}
-            <Grid item>
-              <Button
-                size="small"
-                className={classes.buttonStyle}
-                onClick={removeActionItem}
-              >
-                DELETE
-              </Button>
-            </Grid>
+            <Grid item>{renderClose ? null : renderDeleteButton()}</Grid>
           </Grid>
         </Grid>
       </Grid>
@@ -110,6 +133,7 @@ ActionItemCard.propTypes = {
   description: PropTypes.string.isRequired,
   category: PropTypes.string.isRequired,
   selected: PropTypes.bool.isRequired,
+  renderClose: PropTypes.bool.isRequired,
   dueDate: PropTypes.string,
   handleIconClick: PropTypes.func,
   removeActionItem: PropTypes.func,

--- a/app/javascript/components/ActionItemCard/styles.js
+++ b/app/javascript/components/ActionItemCard/styles.js
@@ -1,4 +1,8 @@
 const styles = theme => ({
+  titleStyle: {
+    maxWidth: '200px',
+    textOverflow: 'ellipsis',
+  },
   iconStyle: {
     backgroundColor: theme.palette.common.lighterBlue,
     margin: '0px 10px',

--- a/app/javascript/components/ActionItemList/index.js
+++ b/app/javascript/components/ActionItemList/index.js
@@ -18,6 +18,7 @@ function ActionItemList({
         dueDate={actionItem.dueDate}
         lastEntry={i === selectedActionItems.length - 1}
         category={actionItem.category}
+        renderClose
         selected
         removeActionItem={() => removeSelectedActionItem(actionItem)}
       />

--- a/app/javascript/components/AddFromExistingForm/index.js
+++ b/app/javascript/components/AddFromExistingForm/index.js
@@ -77,6 +77,7 @@ class AddFromExistingForm extends React.Component {
             description={template.description}
             category={template.category}
             selected={selected}
+            renderClose={false}
             handleIconClick={
               selected
                 ? () => this.props.removeSelectedActionItem(template)


### PR DESCRIPTION
The Figma for the ActionItemCard changed so that if the card is in the ActionItemList (left hand side), it should not have a DELETE button and should instead have an "x" at the top right hand side of the card. This PR does that. It does not include the "EDIT" or "MORE" buttons because they have not been implemented yet.

This PR also contains a styling change and some code cleanup. The most prominent change is that long titles will no longer overflow (they previously did but our titles were never long enough) and will instead be cut off with an ellipsis. The PR screenshot shows a case of this.

### Screenshots
Newest Figma:
![image](https://user-images.githubusercontent.com/35501399/80570443-a17fa280-89af-11ea-97fd-c81edfd2930b.png)


PR has:
![image](https://user-images.githubusercontent.com/35501399/80570341-7006d700-89af-11ea-9a3b-54c3af7eb848.png)



CC: @didvi