### PR TITLE
Red snackbar on failed submission

### DIFF
--- a/app/javascript/components/ActionItemCreationPage/index.js
+++ b/app/javascript/components/ActionItemCreationPage/index.js
@@ -5,6 +5,7 @@ import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 import Divider from '@material-ui/core/Divider';
 import PropTypes from 'prop-types';
+import Snackbar from '@material-ui/core/Snackbar';
 import ActionItemCreationContainer from 'components/ActionItemCreationContainer';
 import ActionItemSearchParticipants from 'components/ActionItemSearchParticipants';
 import ActionItemList from 'components/ActionItemList';
@@ -451,6 +452,14 @@ class ActionItemCreationPage extends React.Component {
 
     return (
       <div>
+        <Snackbar
+          open={this.state.submitFailed}
+          autoHideDuration={3000}
+          message={"You didn't fill out everything dummy"}
+          onClose={() => {
+            this.handleChange('submitFailed')({ target: { value: false } });
+          }}
+        />
         <Dialog open={this.state.submissionModal}>
           <DialogContent>
             <DialogContentText id="alert-dialog-description">
@@ -470,7 +479,7 @@ class ActionItemCreationPage extends React.Component {
             </Button>
           </DialogActions>
         </Dialog>
-        <Grid container style={{ height: '100vh', width: '100vw' }}>
+        <Grid container style={{ height: '100%', width: '100%' }}>
           <Grid item container xs={11} justify="center">
             <Grid
               container

--- a/app/javascript/components/ActionItemCreationPage/index.js
+++ b/app/javascript/components/ActionItemCreationPage/index.js
@@ -6,6 +6,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Divider from '@material-ui/core/Divider';
 import PropTypes from 'prop-types';
 import Snackbar from '@material-ui/core/Snackbar';
+import SnackbarContent from '@material-ui/core/SnackbarContent';
 import ActionItemCreationContainer from 'components/ActionItemCreationContainer';
 import ActionItemSearchParticipants from 'components/ActionItemSearchParticipants';
 import ActionItemList from 'components/ActionItemList';
@@ -448,18 +449,23 @@ class ActionItemCreationPage extends React.Component {
       rightComponentText,
     } = this.getMainComponents(this.state.step);
     const buttonsGrid = this.getButtonsGrid(this.state.step);
-    const errorOccurred = this.state.submitFailed && this.state.step === 2;
+    const submissionError = this.state.submitFailed && this.state.step === 2;
 
     return (
       <div>
         <Snackbar
-          open={this.state.submitFailed}
+          open={submissionError}
           autoHideDuration={3000}
-          message={"You didn't fill out everything dummy"}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
           onClose={() => {
             this.handleChange('submitFailed')({ target: { value: false } });
           }}
-        />
+        >
+          <SnackbarContent
+            classes={{ root: classes.snackbarStyle }}
+            message="There must be at least 1 assignment and 1 student"
+          />
+        </Snackbar>
         <Dialog open={this.state.submissionModal}>
           <DialogContent>
             <DialogContentText id="alert-dialog-description">
@@ -507,16 +513,7 @@ class ActionItemCreationPage extends React.Component {
                 alignItems="flex-start"
               >
                 <Grid item>
-                  <Typography
-                    className={classes.underlineStyle}
-                    style={{
-                      color:
-                        errorOccurred &&
-                        this.state.selectedParticipants.length === 0
-                          ? 'red'
-                          : null,
-                    }}
-                  >
+                  <Typography className={classes.underlineStyle}>
                     {leftComponentText}
                   </Typography>
                   <hr className={classes.borderStyle}></hr>
@@ -524,16 +521,7 @@ class ActionItemCreationPage extends React.Component {
                   {leftComponent}
                 </Grid>
                 <Grid item>
-                  <Typography
-                    className={classes.underlineStyle}
-                    style={{
-                      color:
-                        errorOccurred &&
-                        this.state.selectedActionItems.length === 0
-                          ? 'red'
-                          : null,
-                    }}
-                  >
+                  <Typography className={classes.underlineStyle}>
                     {rightComponentText}
                   </Typography>
                   <hr className={classes.borderStyle}></hr>

--- a/app/javascript/components/ActionItemCreationPage/index.js
+++ b/app/javascript/components/ActionItemCreationPage/index.js
@@ -457,7 +457,10 @@ class ActionItemCreationPage extends React.Component {
           open={submissionError}
           autoHideDuration={3000}
           anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-          onClose={() => {
+          onClose={(event, reason) => {
+            if (reason === 'clickaway') {
+              return;
+            }
             this.handleChange('submitFailed')({ target: { value: false } });
           }}
         >
@@ -485,7 +488,7 @@ class ActionItemCreationPage extends React.Component {
             </Button>
           </DialogActions>
         </Dialog>
-        <Grid container style={{ height: '100%', width: '100%' }}>
+        <Grid container style={{ height: '100vh', width: '100vw' }}>
           <Grid item container xs={11} justify="center">
             <Grid
               container

--- a/app/javascript/components/ActionItemCreationPage/styles.js
+++ b/app/javascript/components/ActionItemCreationPage/styles.js
@@ -4,6 +4,9 @@ const styles = theme => ({
       margin: '0px',
     },
   },
+  snackbarStyle: {
+    backgroundColor: 'red',
+  },
   mainBackgroundStyle: {
     backgroundColor: theme.palette.common.lightestGrey,
     padding: '2%',


### PR DESCRIPTION
Before the top two texts would turn red. We wanted to change it to a snackbar. The snackbar stays active for 3 seconds and fades on clickaway. 


### Screenshots

![image](https://user-images.githubusercontent.com/35501399/80777153-17534d80-8b19-11ea-9f83-9278749374c7.png)


CC: @didvi