### PR TITLE
Fixed error with no dates

### DIFF
--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -17,7 +17,11 @@ class Api::AssignmentsController < ApplicationController
         end
 
         action_items.each do |action_item|
-            due_date = action_item[:due_date] ? DateTime.parse(action_item[:due_date]) : nil
+            begin
+                due_date = DateTime.parse(action_item[:due_date])
+            rescue ArgumentError
+                due_date = nil
+            end
             action_item = ActionItem.new(action_item.except(:due_date)) 
             template_sentry_helper(action_item)
             action_item[:is_template] = false


### PR DESCRIPTION
Previously action items assigned without dates would cause an internal server error because the empty string would try to be parsed as a date and fail. This fixes that.


### Screenshots

Optional but would be nice for final presentation :)


CC: @didvi