### PR TITLE
Made top left header text change depending on step

### DIFF
--- a/app/javascript/components/ActionItemCreationPage/index.js
+++ b/app/javascript/components/ActionItemCreationPage/index.js
@@ -256,10 +256,12 @@ class ActionItemCreationPage extends React.Component {
     let rightComponent;
     let leftComponentText;
     let rightComponentText;
+    let headerText;
     switch (stepSize) {
       case 0:
         leftComponentText = 'Assignments';
         rightComponentText = 'Add Assignments';
+        headerText = 'Add Assignments to List';
         leftComponent = (
           <ActionItemList
             selectedActionItems={this.state.selectedActionItems}
@@ -290,6 +292,8 @@ class ActionItemCreationPage extends React.Component {
       case 1:
         leftComponentText = 'Students';
         rightComponentText = 'Add Students';
+        headerText = 'Add Students to Assignments';
+
         leftComponent = (
           <ActionItemDisplayParticipants
             selectedParticipants={this.state.selectedParticipants}
@@ -310,6 +314,8 @@ class ActionItemCreationPage extends React.Component {
       case 2:
         leftComponentText = 'Review Students';
         rightComponentText = 'Review Assignments';
+        headerText = 'Review and Assign';
+
         leftComponent = (
           <ActionItemDisplayParticipants
             selectedParticipants={this.state.selectedParticipants}
@@ -327,12 +333,14 @@ class ActionItemCreationPage extends React.Component {
         rightComponent = null;
         leftComponentText = null;
         rightComponentText = null;
+        headerText = null;
     }
     return {
       leftComponent,
       rightComponent,
       leftComponentText,
       rightComponentText,
+      headerText,
     };
   }
 
@@ -470,6 +478,7 @@ class ActionItemCreationPage extends React.Component {
       leftComponentText,
       rightComponent,
       rightComponentText,
+      headerText,
     } = this.getMainComponents(this.state.step);
     const buttonsGrid = this.getButtonsGrid(this.state.step);
     const submissionError = this.state.submitFailed && this.state.step === 2;
@@ -525,7 +534,7 @@ class ActionItemCreationPage extends React.Component {
               <Grid container item direction="row" justify="flex-start">
                 <Grid item>
                   <Typography className={classes.topLeftTextStyle}>
-                    Add Assignments to List
+                    {headerText}
                   </Typography>
                 </Grid>
               </Grid>


### PR DESCRIPTION
Wilson brought up that the top left header text wasn't changing as you progressed through stepper. This PR fixes that


### Screenshots

![image](https://user-images.githubusercontent.com/35501399/80894887-4b06b280-8c94-11ea-8b5c-86f9a7add588.png)

![image](https://user-images.githubusercontent.com/35501399/80894890-54901a80-8c94-11ea-8106-029a0056bc9d.png)

![image](https://user-images.githubusercontent.com/35501399/80894897-5d80ec00-8c94-11ea-8f6a-55456f7609fd.png)

CC: @didvi