### PR TITLE
Card buttons no longer misplaced. Added borderBottom to AddFromExisting cards

### DIFF
--- a/app/javascript/components/ActionItemCard/index.js
+++ b/app/javascript/components/ActionItemCard/index.js
@@ -23,7 +23,7 @@ function ActionItemCard({
   handleOpenModal,
   // Used by style file
   // eslint-disable-next-line no-unused-vars
-  lastEntry = false,
+  addBorderBottom,
   handleIconClick,
   removeActionItem,
 }) {
@@ -74,7 +74,6 @@ function ActionItemCard({
     <ThemeProvider theme={theme}>
       <Grid
         container
-        spacing={2}
         className={classes.cardStyle}
         direction="column"
         justify="space-evenly"
@@ -158,6 +157,6 @@ ActionItemCard.propTypes = {
   dueDate: PropTypes.string,
   handleIconClick: PropTypes.func,
   removeActionItem: PropTypes.func,
-  lastEntry: PropTypes.bool,
+  addBorderBottom: PropTypes.bool,
 };
 export default withStyles(styles)(ActionItemCard);

--- a/app/javascript/components/ActionItemCard/styles.js
+++ b/app/javascript/components/ActionItemCard/styles.js
@@ -21,6 +21,8 @@ const styles = theme => ({
     boxShadow: 'none',
     backgroundColor: theme.palette.common.white,
     borderRadius: theme.shape.borderRadius,
+    borderBottom: ({ addBorderBottom }) =>
+      addBorderBottom ? `.75px solid ${theme.palette.common.lightGrey}` : '0px',
   },
   descriptionStyle: {
     textOverflow: 'ellipsis',

--- a/app/javascript/components/ActionItemList/index.js
+++ b/app/javascript/components/ActionItemList/index.js
@@ -18,7 +18,6 @@ function ActionItemList({
       title={actionItem.title}
       description={actionItem.description}
       dueDate={actionItem.dueDate}
-      lastEntry={i === selectedActionItems.length - 1}
       category={actionItem.category}
       handleOpenModal={handleOpenModal(actionItem)}
       renderClose

--- a/app/javascript/components/AddFromExistingForm/index.js
+++ b/app/javascript/components/AddFromExistingForm/index.js
@@ -120,7 +120,8 @@ class AddFromExistingForm extends React.Component {
                 : () => this.handleOpenDateModal(template)
             }
             handleOpenModal={this.props.handleOpenModal(template)}
-            lastEntry={filteredTemplates.length - 1 === i}
+            // Border bottom styling should be added to all cards except the last
+            addBorderBottom={filteredTemplates.length - 1 !== i}
             removeActionItem={() => this.props.deleteTemplate(template)}
           />
         </Grid>


### PR DESCRIPTION
Like title says. I noticed that the borderBottom was removed from the AddFromExisting cards and it made it hard to differentiate when a card ended and started. This reverts it for only the AddFromExisting cards.

## To test:
Please check that it renders well on your screens as well


### Screenshots

![image](https://user-images.githubusercontent.com/35501399/81037001-09be0080-8e56-11ea-9b71-b6918cdfce96.png)


CC: @didvi