### PR TITLE
Fixed snackbar popping up when it was navigated away from too quickly

### DIFF
--- a/app/javascript/components/ActionItemCreationPage/index.js
+++ b/app/javascript/components/ActionItemCreationPage/index.js
@@ -552,7 +552,6 @@ class ActionItemCreationPage extends React.Component {
       headerText,
     } = this.getMainComponents(this.state.step);
     const buttonsGrid = this.getButtonsGrid(this.state.step);
-    const submissionError = this.state.submitFailed && this.state.step === 2;
 
     return (
       <div>
@@ -580,7 +579,7 @@ class ActionItemCreationPage extends React.Component {
           />
         ) : null}
         <Snackbar
-          open={submissionError}
+          open={this.state.submitFailed}
           autoHideDuration={3000}
           anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
           onClose={(event, reason) => {


### PR DESCRIPTION
Divi brought up a bug about the snackbar reappearing if you navigated away from the final step of the modal too quickly after a failed assignment. This PR fixes that. Now, the snackbar follows for 3 seconds no matter where you are in the form.


CC: @didvi