### PR TITLE
Removed edit button from modal

### DIFF
--- a/app/javascript/components/ActionItemCreationPage/index.js
+++ b/app/javascript/components/ActionItemCreationPage/index.js
@@ -94,16 +94,13 @@ class ActionItemCreationPage extends React.Component {
     };
   }
 
-  editActionItem(
+  editActionItem({
     title,
     description,
     categorySelected,
     dueDate,
-    addToTemplates,
-    participantId,
-    actionItemId,
     actionItem,
-  ) {
+  }) {
     this.setState(prevState => {
       const newSelectedActionItems = prevState.selectedActionItems.map(item => {
         const itemCopy = { ...item };

--- a/app/javascript/components/ActionItemModal/index.js
+++ b/app/javascript/components/ActionItemModal/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Fab from '@material-ui/core/Fab';
 import theme from 'utils/theme';
-import Checkbox from '@material-ui/core/Checkbox';
 import Typography from '@material-ui/core/Typography';
 import {
   Button,
@@ -24,7 +23,6 @@ class ActionItemForm extends React.Component {
       categorySelected:
         this.props.type === 'create' ? '' : this.props.categorySelected,
       dueDate: this.props.type === 'create' ? '' : this.props.dueDate,
-      addToTemplates: false,
       failedSubmit: false,
     };
   }
@@ -36,25 +34,18 @@ class ActionItemForm extends React.Component {
 
   handleSubmit = () => {
     const { participantId, actionItemId, actionItem } = this.props;
-    const {
-      title,
-      description,
-      categorySelected,
-      dueDate,
-      addToTemplates,
-    } = this.state;
+    const { title, description, categorySelected, dueDate } = this.state;
 
     if (title && description && categorySelected) {
-      this.props.handleSubmit(
+      this.props.handleSubmit({
         title,
         description,
         categorySelected,
         dueDate,
-        addToTemplates,
         participantId,
         actionItemId,
         actionItem,
-      );
+      });
       this.props.handleClose();
     } else {
       this.setState({ failedSubmit: true });
@@ -63,13 +54,7 @@ class ActionItemForm extends React.Component {
 
   render() {
     const { classes, open } = this.props;
-    const {
-      failedSubmit,
-      title,
-      description,
-      categorySelected,
-      addToTemplates,
-    } = this.state;
+    const { failedSubmit, title, description, categorySelected } = this.state;
 
     const categories = [
       'Finances',
@@ -213,24 +198,7 @@ class ActionItemForm extends React.Component {
             />
           </DialogContent>
           <DialogActions disableSpacing>
-            <Grid container justify="space-between" alignItems="center">
-              <Grid item>
-                <Checkbox
-                  color="primary"
-                  className={classes.checkboxStyle}
-                  checked={addToTemplates}
-                  onChange={e => {
-                    const newValue = { target: { value: e.target.checked } };
-                    this.handleChange('addToTemplates')(newValue);
-                  }}
-                />
-                <Typography
-                  display="inline"
-                  className={classes.checkboxTextStyle}
-                >
-                  ADD TO COMMON ASSIGNMENTS
-                </Typography>
-              </Grid>
+            <Grid container justify="flex-end" alignItems="center">
               <Grid item>
                 <Button onClick={this.handleSubmit}>
                   <Typography


### PR DESCRIPTION
Like title says. 

This might break @claalmve most recent [PR](https://github.com/calblueprint/unloop/pull/129). If it does, he'll need to wrap his `handleSubmit` function parameters around an object since I changed what the function passes (look at my `editActionItem` for how to do this. should be really quick). I did this since using destructuring for the function would be better overall because then order of parameters doesnt matter (and a lot of the parameters aren't used on my end).

### Screenshots
![image](https://user-images.githubusercontent.com/35501399/81464061-819c6b80-9173-11ea-8aab-26f09793b5ac.png)



CC: @didvi