### PR TITLE
[Easy] Assignment page background white + main rectangle scaling on large window

### DIFF
--- a/app/javascript/components/ActionItemCreationPage/index.js
+++ b/app/javascript/components/ActionItemCreationPage/index.js
@@ -614,7 +614,7 @@ class ActionItemCreationPage extends React.Component {
             message="There must be at least 1 assignment and 1 student"
           />
         </Snackbar>
-        <Grid container style={{ height: '100vh', width: '100vw' }}>
+        <Grid container className={classes.pageStyle}>
           <Grid item container xs={11} justify="center">
             <Grid
               container

--- a/app/javascript/components/ActionItemCreationPage/styles.js
+++ b/app/javascript/components/ActionItemCreationPage/styles.js
@@ -1,7 +1,7 @@
 const styles = theme => ({
   pageStyle: {
     minHeight: '100vh',
-    width: '100%',
+    width: '100vw',
     minWidth: '1000px',
     margin: '0px',
     backgroundColor: theme.palette.common.white,
@@ -14,6 +14,7 @@ const styles = theme => ({
     backgroundColor: theme.palette.common.lightestGrey,
     padding: '2%',
     minWidth: '950px',
+    maxHeight: '575px',
     borderRadius: theme.shape.borderRadius,
   },
   iconStyle: {

--- a/app/javascript/components/ActionItemCreationPage/styles.js
+++ b/app/javascript/components/ActionItemCreationPage/styles.js
@@ -1,7 +1,7 @@
 const styles = theme => ({
   pageStyle: {
     minHeight: '100vh',
-    width: '100vw',
+    width: '100%',
     minWidth: '1000px',
     margin: '0px',
     backgroundColor: theme.palette.common.white,


### PR DESCRIPTION
Small PR. Assignment page background now matches figma.

Also the main pink-ish center rectangle used to not scale vertically well (the box would scale but the component wouldn't and it would look ugly). Fixed this by just setting a maxHeight since didn't want to spend too much time on it.


## To Test:
Pull and make sure it looks correct on your screen cause I did this on a large monitor and can't double check it on a laptop screen.

### Screenshots
![image](https://user-images.githubusercontent.com/35501399/81911564-5d30fc80-9582-11ea-91ee-d09e4830e0bd.png)



CC: @didvi